### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Android.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Android.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/AndroidDevice.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/AndroidDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/AndroidDeviceConfig.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/AndroidDeviceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Application.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/ApplicationData.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/ApplicationData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Aps.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Aps.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Blackberry.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Blackberry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/BlackberryDevice.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/BlackberryDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/BlackberryDeviceConfig.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/BlackberryDeviceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Broadcast.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Broadcast.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/ContentReceipt.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/ContentReceipt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Feed.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Feed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedConfig.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedNotificationTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedNotificationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/FeedOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IOSDevice.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IOSDevice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IOSDeviceConfig.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IOSDeviceConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InAppPurchaseOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InAppPurchaseOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IncompleteMessageException.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/IncompleteMessageException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InvalidContentReceiptException.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InvalidContentReceiptException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InventoryItem.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/InventoryItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Notification.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Notification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/OutgoingMessage.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/OutgoingMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PartnerOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PartnerOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Product.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushResponse.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushStatistics.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/PushStatistics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/RegistrationOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/RegistrationOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/RichPushOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/RichPushOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/TagOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/TagOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UrbanAirship.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UrbanAirship.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserConfig.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserCredentials.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserCredentials.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserOperations.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/UserOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/DownloadUrl.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/DownloadUrl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/FeedTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/FeedTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/InAppPurchaseTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/InAppPurchaseTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/PartnerTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/PartnerTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/PushTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/PushTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RecoveryRequest.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RecoveryRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RegistrationTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RegistrationTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RichPushTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/RichPushTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/TagTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/TagTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/UrbanAirshipTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/UrbanAirshipTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/UserTemplate.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/UserTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidDeviceConfigMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidDeviceConfigMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidDeviceMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidDeviceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/AndroidMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApplicationDataMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApplicationDataMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApplicationMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApplicationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApsMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ApsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryDeviceConfigMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryDeviceConfigMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryDeviceMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryDeviceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BlackberryMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BroadcastMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/BroadcastMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ContentReceiptMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ContentReceiptMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/DateDeserializer.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/DateDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/DownloadUrlMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/DownloadUrlMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedConfigMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedConfigMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedNotificationTemplateMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/FeedNotificationTemplateMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/IOSDeviceConfigMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/IOSDeviceConfigMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/IOSDeviceMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/IOSDeviceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/InventoryItemMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/InventoryItemMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ModifyTagsMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ModifyTagsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/NotificationMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/NotificationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/OutgoingMessageMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/OutgoingMessageMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ProductMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/ProductMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/PushResponseMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/PushResponseMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/PushStatisticsMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/PushStatisticsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryRequestMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryRequestMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryResponse.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryResponseMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/RecoveryResponseMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UrbanAirshipModule.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UrbanAirshipModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UserConfigMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UserConfigMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UserCredentialsMixin.java
+++ b/spring-mobile-urbanairship/src/main/java/org/springframework/mobile/urbanairship/impl/json/UserCredentialsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/AbstractUrbanAirshipApiTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/AbstractUrbanAirshipApiTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/FeedTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/FeedTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/InAppPurchaseTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/InAppPurchaseTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/PartnerTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/PartnerTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/PushTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/PushTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/RegistrationTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/RegistrationTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/RichPushTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/RichPushTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/TagTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/TagTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/UserTemplateTest.java
+++ b/spring-mobile-urbanairship/src/test/java/org/springframework/mobile/urbanairship/impl/UserTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/reference/resources/xsl/html-custom.xsl
+++ b/src/reference/resources/xsl/html-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/html-single-custom.xsl
+++ b/src/reference/resources/xsl/html-single-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/src/reference/resources/xsl/pdf-custom.xsl
+++ b/src/reference/resources/xsl/pdf-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 91 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).